### PR TITLE
Dashboard duty can now handle individual users as esclations on services

### DIFF
--- a/dashboard_duty/app.py
+++ b/dashboard_duty/app.py
@@ -22,7 +22,18 @@ def index():
 
     service = d_session.service()
     incidents = d_session.incident(service['id'])
-    oncall = d_session.oncall(service['escalation_policy']['escalation_rules'][0]['targets'][0]['id'])
+
+    if service['escalation_policy']['escalation_rules'][0]['targets'][0]['type'] == 'schedule_reference':
+        service_id = service['escalation_policy']['escalation_rules'][0]['targets'][0]['id']
+        oncall = d_session.oncall_schedule_policy(service_id)
+
+    elif service['escalation_policy']['escalation_rules'][0]['targets'][0]['type'] == 'user_reference':
+        username = service['escalation_policy']['escalation_rules'][0]['targets'][0]['summary']
+        oncall = d_session.oncall_user_policy(username)
+    else:
+        logging.error('Unable to handle oncall policy for %s' % service_key)
+        exit(1)
+
     return render_template('index.html', service=service, incidents=incidents, oncall=oncall)
 
 

--- a/dashboard_duty/dashboard_duty.py
+++ b/dashboard_duty/dashboard_duty.py
@@ -74,7 +74,22 @@ class Core(object):
         out['resolved'] = {'count': len(resolved), 'details': resolved}
         return out
 
-    def oncall(self, schedule_id):
+    def oncall_user_policy(self, username):
+        """
+        If an escalation policy is user_reference this function is called
+        The queries the users API to find the oncall information
+
+        :param username: The PD username of the oncall person
+        :return: The PD user details
+        """
+        payload = {
+            'time_zone': self.timezone,
+            'query': username
+        }
+        r = self._get_url(payload, 'users')
+        return r['users'][0]
+
+    def oncall_schedule_policy(self, schedule_id):
         """
         Takes the escalation target ID of a service and calls the PD API.
         This discovers information regarding the 1st line responder.
@@ -87,13 +102,13 @@ class Core(object):
             'schedule_ids[]': schedule_id
         }
         r = self._get_url(payload, 'oncalls')
-        return r['oncalls'][0]
+        print "%s" % r['oncalls'][0]['user']
+        return r['oncalls'][0]['user']
 
     def service(self):
         """
         Takes the PD service name and calls the PD API
         for details of the service in question
-
 
         :return: The PD service details aligned to the PD service name
         """

--- a/dashboard_duty/templates/index.html
+++ b/dashboard_duty/templates/index.html
@@ -115,6 +115,6 @@
 
 <div class="panel panel-default">
     <div class="panel-body text-center">
-        <a href="{{ oncall.user.html_url }}">Current on-call: {{ oncall.user.summary }}</a>
+        <a href="{{ oncall.html_url }}">Current on-call: {{ oncall.summary }}</a>
     </div>
 </div>


### PR DESCRIPTION
Previously an exception was thrown as DD could only handle having a schedule assigned to an escalation policy. Now the service data is interrogated properly to determine whether it is a schedule or user, making the required API call based off this information.